### PR TITLE
Feature/refactor to use new bm62 driver

### DIFF
--- a/Opossum.ino
+++ b/Opossum.ino
@@ -65,7 +65,7 @@ volatile uint8_t S2ButtonPressCount = 0;
 volatile uint32_t S2DebounceStart, S2DebounceStop = 0;
 
 // define if serial UART port should be initialized when BM62 is init
-bool BM62_initSerialPort = false;
+bool BM62_initSerialPort = true;
 
 // create BM62 driver object
 BM62 bluetooth(BM62_initSerialPort);
@@ -205,21 +205,8 @@ void updateVolumeRange(void) {
 
 // set up and configure the MCU, BM62, and MSGEQ7
 void setup() {
-  /*
-  // initialize the BM62 reset line and ensure reset is asserted
-  pinMode(RST_N, OUTPUT);
-  digitalWrite(RST_N, LOW);
-  
-  // wait 10 ms, then take the BM62 out of reset
-  delay(10);
-  digitalWrite(RST_N, HIGH);
-  
-  // determine if the BM62 is being programmed; if so, take a nap
-  pinMode(PRGM_SENSE_N, INPUT);
-  BM62_isProgramMode();
-  */
-
- bluetooth.init();
+  // initialize the BM62 bluetooth device
+  bluetooth.init();
 
   // initialize remaining digital pin modes
   pinMode(S2_INT,     INPUT);
@@ -248,9 +235,6 @@ void setup() {
 
   // wait for the BM62 to indicate a successful A2DP connection
   waitForConnection();
-
-  // initialize the UART port to talk to the BM62
-  //Serial.begin(57600, SERIAL_8N1);
 
   // initialize Wire library and set clock rate to 400 kHz
   Wire.begin();
@@ -286,9 +270,6 @@ void loop() {
   if (bluetooth.read(IND_A2DP_N)) {
     // if A2DP connection is lost, halt and wait for reconnection
     waitForConnection();
-    
-    // start playback from media device
-    //Serial.write(BM62_Play, 7);
   }
   
   // get the elapsed time, in millisecionds, since power-on

--- a/Opossum.ino
+++ b/Opossum.ino
@@ -235,6 +235,7 @@ void setup() {
 
   // wait for the BM62 to indicate a successful A2DP connection
   waitForConnection();
+  bluetooth.stop();
 
   // initialize Wire library and set clock rate to 400 kHz
   Wire.begin();
@@ -270,6 +271,7 @@ void loop() {
   if (bluetooth.read(IND_A2DP_N)) {
     // if A2DP connection is lost, halt and wait for reconnection
     waitForConnection();
+    bluetooth.stop();
   }
   
   // get the elapsed time, in millisecionds, since power-on

--- a/opossum/BM62.h
+++ b/opossum/BM62.h
@@ -116,23 +116,23 @@ class BM62 {
     bool read(uint8_t pin) {
       return (bool)digitalRead(pin);
     }
-    void play(uint8_t pin) {
+    void play(void) {
       // start playback from bluetooth-connected media device
       Serial.write(BM62_Play, BYTE_COUNT_MEDIACONTROL);
     }
-    void pause(uint8_t pin) {
+    void pause(void) {
       // pause playback from bluetooth-connected media device
       Serial.write(BM62_Pause, BYTE_COUNT_MEDIACONTROL);
     }
-    void stop(uint8_t pin) {
+    void stop(void) {
       // stop playback from bluetooth-connected media device
       Serial.write(BM62_Stop, BYTE_COUNT_MEDIACONTROL);
     }
-    void prev(uint8_t pin) {
+    void prev(void) {
       // go to previous track on bluetooth-connected media device
       Serial.write(BM62_PrevTrack, BYTE_COUNT_MEDIACONTROL);
     }
-    void next(uint8_t pin) {
+    void next(void) {
       // go to next track on bluetooth-connected media device
       Serial.write(BM62_NextTrack, BYTE_COUNT_MEDIACONTROL);
     }

--- a/opossum/BM62.h
+++ b/opossum/BM62.h
@@ -117,18 +117,23 @@ class BM62 {
       return (bool)digitalRead(pin);
     }
     void play(uint8_t pin) {
+      // start playback from bluetooth-connected media device
       Serial.write(BM62_Play, BYTE_COUNT_MEDIACONTROL);
     }
     void pause(uint8_t pin) {
+      // pause playback from bluetooth-connected media device
       Serial.write(BM62_Pause, BYTE_COUNT_MEDIACONTROL);
     }
     void stop(uint8_t pin) {
+      // stop playback from bluetooth-connected media device
       Serial.write(BM62_Stop, BYTE_COUNT_MEDIACONTROL);
     }
     void prev(uint8_t pin) {
+      // go to previous track on bluetooth-connected media device
       Serial.write(BM62_PrevTrack, BYTE_COUNT_MEDIACONTROL);
     }
     void next(uint8_t pin) {
+      // go to next track on bluetooth-connected media device
       Serial.write(BM62_NextTrack, BYTE_COUNT_MEDIACONTROL);
     }
 };

--- a/opossum/BM62.h
+++ b/opossum/BM62.h
@@ -142,22 +142,22 @@ class BM62 {
     }
     void play(void) {
       // start playback from bluetooth-connected media device
-      Serial.write(BM62_Play, BYTE_COUNT_MEDIACONTROL);
+      writeMediaCommand(BM62_Play);
     }
     void pause(void) {
       // pause playback from bluetooth-connected media device
-      Serial.write(BM62_Pause, BYTE_COUNT_MEDIACONTROL);
+      writeMediaCommand(BM62_Pause);
     }
     void stop(void) {
       // stop playback from bluetooth-connected media device
-      Serial.write(BM62_Stop, BYTE_COUNT_MEDIACONTROL);
+      writeMediaCommand(BM62_Stop);
     }
     void prev(void) {
       // go to previous track on bluetooth-connected media device
-      Serial.write(BM62_PrevTrack, BYTE_COUNT_MEDIACONTROL);
+      writeMediaCommand(BM62_Prev_Track);
     }
     void next(void) {
       // go to next track on bluetooth-connected media device
-      Serial.write(BM62_NextTrack, BYTE_COUNT_MEDIACONTROL);
+      writeMediaCommand(BM62_Next_Track);
     }
 };

--- a/opossum/BM62.h
+++ b/opossum/BM62.h
@@ -21,8 +21,14 @@
 
 class BM62 {
   private:
-    #ifndef BYTE_COUNT_MEDIACONTROL
-      #define BYTE_COUNT_MEDIACONTROL (uint8_t)7
+    #ifndef BYTE_COUNT_MEDIA_COMMAND
+      #define BYTE_COUNT_MEDIA_COMMAND (uint8_t)7
+    #endif
+    #ifndef BYTE_COUNT_MEDIA_PREFIX
+      #define BYTE_COUNT_MEDIA_PREFIX (uint8_t)3
+    #endif
+    #ifndef BYTE_COUNT_MEDIA_INSTRUCTION
+      #define BYTE_COUNT_MEDIA_INSTRUCTION (uint8_t)3
     #endif
     #ifndef SERIAL_BAUD_RATE
       #define SERIAL_BAUD_RATE (uint16_t)57600
@@ -31,25 +37,29 @@ class BM62 {
     bool initSerialPort;
 
     // BM62 UART commands for media playback control
-    const uint8_t BM62_Play[BYTE_COUNT_MEDIACONTROL] =
+    uint8_t BM62_Media_Command[BYTE_COUNT_MEDIA_COMMAND] =
     {
-        0xAA, 0x00, 0x03, 0x04, 0x00, 0x05, 0xF4
+        0xAA, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00
     };
-    const uint8_t BM62_Pause[BYTE_COUNT_MEDIACONTROL] =
+    const uint8_t BM62_Play[BYTE_COUNT_MEDIA_INSTRUCTION] =
     {
-        0xAA, 0x00, 0x03, 0x04, 0x00, 0x06, 0xF3
+        0x04, 0x00, 0x05
     };
-    const uint8_t BM62_Stop[BYTE_COUNT_MEDIACONTROL] =
+    const uint8_t BM62_Pause[BYTE_COUNT_MEDIA_INSTRUCTION] =
     {
-        0xAA, 0x00, 0x03, 0x04, 0x00, 0x08, 0xF1
+        0x04, 0x00, 0x06
     };
-    const uint8_t BM62_PrevTrack[BYTE_COUNT_MEDIACONTROL] =
+    const uint8_t BM62_Stop[BYTE_COUNT_MEDIA_INSTRUCTION] =
     {
-        0xAA, 0x00, 0x03, 0x02, 0x00, 0x35, 0xC6
+        0x04, 0x00, 0x08
     };
-    const uint8_t BM62_NextTrack[BYTE_COUNT_MEDIACONTROL] =
+    const uint8_t BM62_Prev_Track[BYTE_COUNT_MEDIA_INSTRUCTION] =
     {
-        0xAA, 0x00, 0x03, 0x02, 0x00, 0x34, 0xC7
+        0x02, 0x00, 0x35
+    };
+    const uint8_t BM62_Next_Track[BYTE_COUNT_MEDIA_INSTRUCTION] =
+    {
+        0x02, 0x00, 0x34
     };
 
     // check if the BM62 programming pin is pulled low

--- a/opossum/drivers.h
+++ b/opossum/drivers.h
@@ -21,62 +21,6 @@
 
   #include "parameters.h"
 
- /*
-  *  ########################
-  *  BM62 Bluetooth Interface
-  *  ########################
-  */
- /*
-  // BM62 UART commands for media playback control
-  const uint8_t BM62_Play[7] =
-  {
-    0xAA, 0x00, 0x03, 0x04, 0x00, 0x05, 0xF4
-  };
-  const uint8_t BM62_Pause[7] =
-  {
-    0xAA, 0x00, 0x03, 0x04, 0x00, 0x06, 0xF3
-  };
-  const uint8_t BM62_Stop[7] =
-  {
-    0xAA, 0x00, 0x03, 0x04, 0x00, 0x08, 0xF1
-  };
-  const uint8_t BM62_PrevTrack[7] =
-  {
-    0xAA, 0x00, 0x03, 0x02, 0x00, 0x35, 0xC6
-  };
-  const uint8_t BM62_NextTrack[7] =
-  {
-    0xAA, 0x00, 0x03, 0x02, 0x00, 0x34, 0xC7
-  };
-
-  // check if the BM62 programming pin is pulled low
-  void BM62_isProgramMode(void) {
-    if (!digitalRead(PRGM_SENSE_N)) {
-      set_sleep_mode(SLEEP_MODE_PWR_DOWN);  // set sleep mode to power down
-      cli();                                // globally disable interrupts
-      sleep_enable();                       // set sleep bit
-      sleep_bod_disable();                  // disable brown out detection
-      sleep_cpu();                          // go to sleep
-      
-      // interrupts are disabled, mcu will NOT wake up until next power cycle!
-    }
-  }
-
-  // for calculating the checksum of a BM62 UART command:
-  byte BM62_checksum(uint8_t a[], uint8_t numel) {
-    // BM62 documentation is lacking but pretty sure
-    uint16_t sum = 0;
-    for (uint8_t k = 2; k < numel - 1; k++) {
-      sum = sum + a[k];
-    }
-
-    // subtract sum from 0xFFFF and add one; use only the lower byte
-    sum = ((uint16_t)0xFFFF - sum) + (uint16_t)0x0001;
-    return(lowByte(sum));
-  }
-*/
-
-
  /*  
   *  ##############################
   *  MSGEQ7 Spectrum Level Detector

--- a/opossum/drivers.h
+++ b/opossum/drivers.h
@@ -26,6 +26,7 @@
   *  BM62 Bluetooth Interface
   *  ########################
   */
+ /*
   // BM62 UART commands for media playback control
   const uint8_t BM62_Play[7] =
   {
@@ -73,7 +74,7 @@
     sum = ((uint16_t)0xFFFF - sum) + (uint16_t)0x0001;
     return(lowByte(sum));
   }
-
+*/
 
 
  /*  


### PR DESCRIPTION
This feature refactors the BM62 driver to use a new BM62 driver class, allowing the hardware to be instantiated as a single object. Consolidating the BM62 driver code in the manner has also freed up SRAM resources, though that may not be true for the smaller drivers.

This is part of a larger effort to refactor all of the hardware drivers, which make the non-driver program code much easier to work with and make implementing the automatic gain much less of a headache.