### PR TITLE
Feature/refactor to use new msgeq7 driver

### DIFF
--- a/Opossum.ino
+++ b/Opossum.ino
@@ -78,7 +78,6 @@ bool MSGEQ7_isInputPullup = false;
 MSGEQ7 spectrum(MSGEQ7_isInputPullup);
 
 
-
 // wait for BM62 to indicate a successful A2DP connection
 void waitForConnection(void) {
   while (bluetooth.read(IND_A2DP_N)) {
@@ -143,7 +142,6 @@ void waitForConnection(void) {
 }
 
 
-
 // use a 32-value circular buffer to track audio levels
 uint16_t expDecayBuf(uint16_t levelReadMean) {
   if (bufferIndx >= 32) {
@@ -177,14 +175,12 @@ uint16_t expDecayBuf(uint16_t levelReadMean) {
 }
 
 
-
 // update the relative dB level bands using currently defined volume level
 void dBFastRelativeLevel(void) {
   for(uint8_t k = 0; k < 25; k++) {
     dBLevs[k] = ((uint32_t)baseLevel * pgm_read_word(&(dBCoefTable[k]))) >> 12;
   }
 }
-
 
 
 // calculate allowable MAX9744 volume adjustment range
@@ -209,7 +205,6 @@ void updateVolumeRange(void) {
 }
 
 
-
 // set up and configure the MCU, BM62, and MSGEQ7
 void setup() {
   // initialize the BM62 bluetooth device
@@ -228,13 +223,6 @@ void setup() {
   // ensure both LEDs are turned off
   digitalWrite(S1_LEDPWM, LOW);
   digitalWrite(S2_LEDPWM, LOW);
-
-  // set analog input pullup to minimize glitchy MSGEQ7 reads
-  //digitalWrite(A1, INPUT);
-
-  // set MSGEQ7 strobe low, and reset high
-  //digitalWrite(STROBE, LOW);
-  //digitalWrite(RESET, HIGH);
 
   // initialize the MSGEQ7
   spectrum.init();
@@ -274,7 +262,6 @@ void setup() {
   baseLevel = levelOut;
   dBFastRelativeLevel();
 }
-
 
 
 void loop() {

--- a/Opossum.ino
+++ b/Opossum.ino
@@ -22,6 +22,7 @@
 #include <Wire.h>
 
 #include "opossum/BM62.h"
+#include "opossum/MSGEQ7.h"
 #include "opossum/drivers.h"
 #include "opossum/parameters.h"
 
@@ -69,6 +70,12 @@ bool BM62_initSerialPort = true;
 
 // create BM62 driver object
 BM62 bluetooth(BM62_initSerialPort);
+
+// define if analog input pullup should be set active when MSGEQ7 is init
+bool MSGEQ7_isInputPullup = false;
+
+// create BM62 driver object
+MSGEQ7 spectrum(MSGEQ7_isInputPullup);
 
 
 
@@ -213,8 +220,8 @@ void setup() {
   //pinMode(IND_A2DP_N, INPUT_PULLUP);
   pinMode(S2_LEDPWM,  OUTPUT);
   pinMode(S1_LEDPWM,  OUTPUT);
-  pinMode(STROBE,     OUTPUT);
-  pinMode(RESET,      OUTPUT);
+  //pinMode(STROBE,     OUTPUT);
+  //pinMode(RESET,      OUTPUT);
   pinMode(MUTE,       OUTPUT);
   pinMode(SHDN,       OUTPUT);  
 
@@ -223,11 +230,14 @@ void setup() {
   digitalWrite(S2_LEDPWM, LOW);
 
   // set analog input pullup to minimize glitchy MSGEQ7 reads
-  digitalWrite(A1, INPUT);
+  //digitalWrite(A1, INPUT);
 
   // set MSGEQ7 strobe low, and reset high
-  digitalWrite(STROBE, LOW);
-  digitalWrite(RESET, HIGH);
+  //digitalWrite(STROBE, LOW);
+  //digitalWrite(RESET, HIGH);
+
+  // initialize the MSGEQ7
+  spectrum.init();
 
   // mute the MAX9744 then take it out of shutdown
   digitalWrite(MUTE, LOW);
@@ -257,8 +267,8 @@ void setup() {
   }
   
   // read weighted audio level data, find mean, calculate buffer value
-  MSGEQ7_read(levelRead);
-  levelOut = expDecayBuf(MSGEQ7_mean(levelRead));
+  spectrum.read(levelRead);
+  levelOut = expDecayBuf(spectrum.mean(levelRead));
 
   // initialize base volume level and relative dB values
   baseLevel = levelOut;
@@ -283,8 +293,8 @@ void loop() {
     previousMillis = currentMillis;
 
     // read weighted audio level data, find mean, calculate buffer value
-    MSGEQ7_read(levelRead);
-    levelOut = expDecayBuf(MSGEQ7_mean(levelRead));
+    spectrum.read(levelRead);
+    levelOut = expDecayBuf(spectrum.mean(levelRead));
 
     #if defined DEBUG
       uint16_t levelDebug[2] = {(uint16_t)(lowByte(volOut >> 4)), levelOut};

--- a/opossum/MSGEQ7.h
+++ b/opossum/MSGEQ7.h
@@ -1,0 +1,91 @@
+/*
+ * MSGEQ7.h - MSI MSGEQ7 Seven Band Graphic Equalizer Driver for Arduino
+ * Copyright (c) 2017 Winry R. Litwa-Vulcu. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "parameters.h"
+
+class MSGEQ7 {
+  private:
+    bool isInputPullup;
+
+  public:
+    MSGEQ7(bool isInputPullup) {
+      // Use 'this->' to make the difference between the 'pin' 
+      // attribute of the class and the local variable
+      this->isInputPullup = isInputPullup;
+    }
+    void init(void) {
+      // initialize the MSGEQ7 reset and strobe signals
+      pinMode(STROBE, OUTPUT);
+      pinMode(RESET,  OUTPUT);
+
+      // set MSGEQ7 strobe low, and reset high (put device in standby)
+      digitalWrite(STROBE, LOW);
+      digitalWrite(RESET, HIGH);
+
+      if (isInputPullup) {
+        // initialize analog input 1 with internal pullup active
+        digitalWrite(A1, INPUT_PULLUP);
+      }
+      else {
+        // initialize analog input 1 without internal pullup active
+        digitalWrite(A1, INPUT);
+      }
+    }
+    void read(uint16_t *levelRead) {
+      // read back spectral band data from the MSGEQ7
+      // start by setting RESET pin low to enable output
+      digitalWrite(RESET, LOW);
+      delayMicroseconds(100);
+
+      // pulse STROBE pin to read all 7 frequency bands
+      for(uint8_t k = 0; k < 7; k++) {
+        // set STROBE pin low to enable output
+        digitalWrite(STROBE, LOW);
+        delayMicroseconds(65);
+
+        // read signal band level, account for later loudness adj.
+        levelRead[k] = analogRead(DCOUT) << 3;
+
+        // set STROBE pin high again to prepare for next band reading
+        digitalWrite(STROBE, HIGH);
+        delayMicroseconds(35);
+      }
+
+      // set RESET high again to reset MSGEQ7 multiplexer
+      digitalWrite(RESET, HIGH);
+
+      // spectral band adj. (very) loosely based on ISO 226:2003 [60 phons]
+      levelRead[0] = levelRead[0] >> 3;   //   63 Hz
+      levelRead[1] = levelRead[1] >> 1;   //  160 Hz
+      levelRead[2] = levelRead[2] >> 0;   //  400 Hz
+      levelRead[3] = levelRead[3] << 0;   // 1000 Hz
+      levelRead[4] = levelRead[4] << 0;   // 2500 Hz
+      levelRead[5] = levelRead[5] >> 1;   // 6250 Hz
+      levelRead[6] = levelRead[6] >> 2;   //16000 Hz
+    }
+    uint16_t mean(uint16_t *levelRead) {
+      // find mean of levelRead array data read from MSGEQ7
+      // calculate the sum of levelRead array
+      uint16_t sum = 0;
+      for(uint8_t k = 0; k < 7; k++) {
+        sum = sum + levelRead[k];
+      }
+      // much faster than divide-by-7, accurate to 7.00
+      return (sum * 585L) >> 12;
+    }
+};

--- a/opossum/MSGEQ7.h
+++ b/opossum/MSGEQ7.h
@@ -22,12 +22,15 @@ class MSGEQ7 {
   private:
     bool isInputPullup;
 
+
   public:
     MSGEQ7(bool isInputPullup) {
       // Use 'this->' to make the difference between the 'pin' 
       // attribute of the class and the local variable
       this->isInputPullup = isInputPullup;
     }
+
+
     void init(void) {
       // initialize the MSGEQ7 reset and strobe signals
       pinMode(STROBE, OUTPUT);
@@ -46,6 +49,8 @@ class MSGEQ7 {
         digitalWrite(A1, INPUT);
       }
     }
+
+
     void read(uint16_t *levelRead) {
       // read back spectral band data from the MSGEQ7
       // start by setting RESET pin low to enable output
@@ -78,6 +83,8 @@ class MSGEQ7 {
       levelRead[5] = levelRead[5] >> 1;   // 6250 Hz
       levelRead[6] = levelRead[6] >> 2;   //16000 Hz
     }
+
+
     uint16_t mean(uint16_t *levelRead) {
       // find mean of levelRead array data read from MSGEQ7
       // calculate the sum of levelRead array

--- a/opossum/drivers.h
+++ b/opossum/drivers.h
@@ -26,6 +26,7 @@
   *  MSGEQ7 Spectrum Level Detector
   *  ##############################
   */
+ /*
   // read back spectral band data from the MSGEQ7
   void MSGEQ7_read(uint16_t *levelRead) {
     // set RESET pin low to enable output
@@ -69,7 +70,7 @@
     // much faster than divide-by-7, accurate to 7.00
     return (sum * 585L) >> 12;
   }
-
+*/
 
 
  /*  

--- a/opossum/drivers.h
+++ b/opossum/drivers.h
@@ -22,58 +22,6 @@
   #include "parameters.h"
 
  /*  
-  *  ##############################
-  *  MSGEQ7 Spectrum Level Detector
-  *  ##############################
-  */
- /*
-  // read back spectral band data from the MSGEQ7
-  void MSGEQ7_read(uint16_t *levelRead) {
-    // set RESET pin low to enable output
-    digitalWrite(RESET, LOW);
-    delayMicroseconds(100);
-
-    // pulse STROBE pin to read all 7 frequency bands
-    for(uint8_t k = 0; k < 7; k++) {
-      // set STROBE pin low to enable output
-      digitalWrite(STROBE, LOW);
-      delayMicroseconds(65);
-
-      // read signal band level, account for later loudness adj.
-      levelRead[k] = analogRead(DCOUT) << 3;
-
-      // set STROBE pin high again to prepare for next band reading
-      digitalWrite(STROBE, HIGH);
-      delayMicroseconds(35);
-    }
-
-    // set RESET high again to reset MSGEQ7 multiplexer
-    digitalWrite(RESET, HIGH);
-
-    // spectral band adj. (very) loosely based on ISO 226:2003 [60 phons]
-    levelRead[0] = levelRead[0] >> 3;   //   63 Hz
-    levelRead[1] = levelRead[1] >> 1;   //  160 Hz
-    levelRead[2] = levelRead[2] >> 0;   //  400 Hz
-    levelRead[3] = levelRead[3] << 0;   // 1000 Hz
-    levelRead[4] = levelRead[4] << 0;   // 2500 Hz
-    levelRead[5] = levelRead[5] >> 1;   // 6250 Hz
-    levelRead[6] = levelRead[6] >> 2;   //16000 Hz
-  }
-
-  // find mean of levelRead array data read from MSGEQ7
-  uint16_t MSGEQ7_mean(uint16_t *levelRead) {
-    // calculate the sum of levelRead array
-    uint16_t sum = 0;
-    for(uint8_t k = 0; k < 7; k++) {
-      sum = sum + levelRead[k];
-    }
-    // much faster than divide-by-7, accurate to 7.00
-    return (sum * 585L) >> 12;
-  }
-*/
-
-
- /*  
   *  #################
   *  MAX9744 Amplifier
   *  #################


### PR DESCRIPTION
This feature refactors the MSGEQ7 driver to use a new MSGEQ7 driver class, allowing the hardware to be instantiated as a single object.

This is part of a larger effort to refactor all of the hardware drivers, which make the non-driver program code much easier to work with and make implementing the automatic gain much less of a headache.