### PR TITLE
fixed enable()/reset() logic inversion in BM62 driver

### DIFF
--- a/opossum/BM62.h
+++ b/opossum/BM62.h
@@ -117,7 +117,7 @@ class BM62 {
 
     void enable(void) {
       // set BM62 reset status, active-low signal so HIGH enables device
-      digitalWrite(RST_N, LOW);
+      digitalWrite(RST_N, HIGH);
     }
 
 
@@ -154,7 +154,7 @@ class BM62 {
 
     void reset(void) {
       // set BM62 reset status, active-low signal so LOW puts device in reset
-      digitalWrite(RST_N, HIGH);
+      digitalWrite(RST_N, LOW);
     }
 
 


### PR DESCRIPTION
public methods enable() and reset() were inverted logically, so the device was not initialized correctly and was held in a reset state