### PR TITLE
Experimental/modify drivers to require pin numbers on init

### DIFF
--- a/Opossum.ino
+++ b/Opossum.ino
@@ -18,13 +18,12 @@
 
 // include libraries for PROGMEM, SLEEP, & I2C
 #include <avr/pgmspace.h>
-#include <avr/sleep.h>
 #include <Wire.h>
 
+#include "opossum/parameters.h"
 #include "opossum/BM62.h"
 #include "opossum/MSGEQ7.h"
 #include "opossum/drivers.h"
-#include "opossum/parameters.h"
 
 // comment to deactivate UART debug mode
 #define DEBUG
@@ -69,13 +68,13 @@ volatile uint32_t S2DebounceStart, S2DebounceStop = 0;
 bool BM62_initSerialPort = true;
 
 // create BM62 driver object
-BM62 bluetooth(BM62_initSerialPort);
+BM62 bluetooth(PRGM_SENSE_N, RST_N, IND_A2DP_N, BM62_initSerialPort);
 
 // define if analog input pullup should be set active when MSGEQ7 is init
 bool MSGEQ7_isInputPullup = false;
 
 // create BM62 driver object
-MSGEQ7 spectrum(MSGEQ7_isInputPullup);
+MSGEQ7 spectrum(STROBE, OUTPUT, RESET, MSGEQ7_isInputPullup);
 
 
 // wait for BM62 to indicate a successful A2DP connection

--- a/opossum/BM62.h
+++ b/opossum/BM62.h
@@ -17,9 +17,101 @@
  */
 
 class BM62 {
+  public:
+    BM62(uint8_t prgm_sense_n, uint8_t reset_n, uint8_t ind_a2dp_n, bool initSerialPort) {
+      // Use 'this->' to make the difference between the 'pin' 
+      // attribute of the class and the local variable
+      this->prgm_sense_n = prgm_sense_n;
+      this->reset_n = reset_n;
+      this->ind_a2dp_n = ind_a2dp_n;
+      this->initSerialPort = initSerialPort;
+    }
+
+
+    void enable(void) {
+      // set BM62 reset status, active-low signal so HIGH enables device
+      digitalWrite(reset_n, LOW);
+    }
+
+
+    void init(void) {
+      // initialize the BM62 reset line and ensure reset is asserted
+      pinMode(reset_n, OUTPUT);
+      reset();
+
+      // wait 10 ms, then take the BM62 out of reset
+      delay(10);
+      enable();
+      
+      // initialize the BM62 programming sense line
+      pinMode(prgm_sense_n, INPUT);
+
+      // determine if the BM62 is being programmed; if so, take a nap
+      isProgramMode();
+
+      // input for determining if a successful A2DP connection active
+      pinMode(ind_a2dp_n, INPUT_PULLUP);
+
+      if (initSerialPort) {
+        // initialize the UART port to talk to the BM62
+        Serial.begin(SERIAL_BAUD_RATE, SERIAL_8N1);
+      }
+    }
+
+
+    bool isConnected(void) {
+      // query state of BM62 IND_A2DP_N pin and return FALSE if no active A2DP connection
+      return (bool)!digitalRead(ind_a2dp_n);
+    }
+
+
+    void reset(void) {
+      // set BM62 reset status, active-low signal so LOW puts device in reset
+      digitalWrite(reset_n, HIGH);
+    }
+
+
+    void play(void) {
+      // start playback from bluetooth-connected media device
+      if (isConnected()) {
+        writeMediaCommand(BM62_Play);
+      }
+    }
+
+
+    void pause(void) {
+      // pause playback from bluetooth-connected media device
+      if (isConnected()) {
+        writeMediaCommand(BM62_Pause);
+      }
+    }
+
+
+    void stop(void) {
+      // stop playback from bluetooth-connected media device
+      if (isConnected()) {
+        writeMediaCommand(BM62_Stop);
+      }
+    }
+
+
+    void prev(void) {
+      // go to previous track on bluetooth-connected media device
+      if (isConnected()) {
+        writeMediaCommand(BM62_Prev_Track);
+      }
+    }
+
+
+    void next(void) {
+      // go to next track on bluetooth-connected media device
+      if (isConnected()) {
+        writeMediaCommand(BM62_Next_Track);
+      }
+    }
+
   private:
     #include <avr/sleep.h>
-    #include "parameters.h"  
 
     #ifndef BYTE_COUNT_MEDIA_COMMAND
       #define BYTE_COUNT_MEDIA_COMMAND (uint8_t)7
@@ -31,10 +123,14 @@ class BM62 {
       #define BYTE_COUNT_MEDIA_INSTRUCTION (uint8_t)3
     #endif
     #ifndef SERIAL_BAUD_RATE
+      // this must be 57600 for the BM62 but may be defined elsewhere
       #define SERIAL_BAUD_RATE (uint16_t)57600
     #endif
 
     bool initSerialPort;
+    uint8_t prgm_sense_n;
+    uint8_t reset_n;
+    uint8_t ind_a2dp_n;
 
     // BM62 UART commands for media playback control
     uint8_t BM62_Media_Command[BYTE_COUNT_MEDIA_COMMAND] =
@@ -87,7 +183,7 @@ class BM62 {
 
     // check if the BM62 programming pin is pulled low
     void isProgramMode(void) {
-      if (!digitalRead(PRGM_SENSE_N)) {
+      if (!digitalRead(prgm_sense_n)) {
         set_sleep_mode(SLEEP_MODE_PWR_DOWN);  // set sleep mode to power down
         cli();                                // globally disable interrupts
         sleep_enable();                       // set sleep bit
@@ -104,96 +200,5 @@ class BM62 {
         uint8_t mediaCommand[BYTE_COUNT_MEDIA_COMMAND];
         buildMediaCommand(mediaCommand, (uint8_t *)instruction);
         Serial.write(mediaCommand, BYTE_COUNT_MEDIA_COMMAND);
-    }
-
-
-  public:
-    BM62(bool initSerialPort) {
-      // Use 'this->' to make the difference between the 'pin' 
-      // attribute of the class and the local variable
-      this->initSerialPort = initSerialPort;
-    }
-
-
-    void enable(void) {
-      // set BM62 reset status, active-low signal so HIGH enables device
-      digitalWrite(RST_N, LOW);
-    }
-
-
-    void init(void) {
-      // initialize the BM62 reset line and ensure reset is asserted
-      pinMode(RST_N, OUTPUT);
-      reset();
-
-      // wait 10 ms, then take the BM62 out of reset
-      delay(10);
-      enable();
-      
-      // initialize the BM62 programming sense line
-      pinMode(PRGM_SENSE_N, INPUT);
-
-      // determine if the BM62 is being programmed; if so, take a nap
-      isProgramMode();
-
-      // input for determining if a successful A2DP connection active
-      pinMode(IND_A2DP_N, INPUT_PULLUP);
-
-      if (initSerialPort) {
-        // initialize the UART port to talk to the BM62
-        Serial.begin(SERIAL_BAUD_RATE, SERIAL_8N1);
-      }
-    }
-
-
-    bool isConnected(void) {
-      // query state of BM62 IND_A2DP_N pin and return FALSE if no active A2DP connection
-      return (bool)!digitalRead(IND_A2DP_N);
-    }
-
-
-    void reset(void) {
-      // set BM62 reset status, active-low signal so LOW puts device in reset
-      digitalWrite(RST_N, HIGH);
-    }
-
-
-    void play(void) {
-      // start playback from bluetooth-connected media device
-      if (isConnected()) {
-        writeMediaCommand(BM62_Play);
-      }
-    }
-
-
-    void pause(void) {
-      // pause playback from bluetooth-connected media device
-      if (isConnected()) {
-        writeMediaCommand(BM62_Pause);
-      }
-    }
-
-
-    void stop(void) {
-      // stop playback from bluetooth-connected media device
-      if (isConnected()) {
-        writeMediaCommand(BM62_Stop);
-      }
-    }
-
-
-    void prev(void) {
-      // go to previous track on bluetooth-connected media device
-      if (isConnected()) {
-        writeMediaCommand(BM62_Prev_Track);
-      }
-    }
-
-
-    void next(void) {
-      // go to next track on bluetooth-connected media device
-      if (isConnected()) {
-        writeMediaCommand(BM62_Next_Track);
-      }
     }
 };

--- a/opossum/MSGEQ7.h
+++ b/opossum/MSGEQ7.h
@@ -17,36 +17,33 @@
  */
 
 class MSGEQ7 {
-  private:
-    #include "parameters.h"
-
-    bool isInputPullup;
-
-
   public:
-    MSGEQ7(bool isInputPullup) {
+    MSGEQ7(uint8_t strobe, uint8_t output, uint8_t reset, bool isInputPullup) {
       // Use 'this->' to make the difference between the 'pin' 
       // attribute of the class and the local variable
+      this->strobe = strobe;
+      this->output = output;
+      this->reset = reset;
       this->isInputPullup = isInputPullup;
     }
 
 
     void init(void) {
       // initialize the MSGEQ7 reset and strobe signals
-      pinMode(STROBE, OUTPUT);
-      pinMode(RESET,  OUTPUT);
+      pinMode(strobe, OUTPUT);
+      pinMode(reset,  OUTPUT);
 
       // set MSGEQ7 strobe low, and reset high (put device in standby)
-      digitalWrite(STROBE, LOW);
-      digitalWrite(RESET, HIGH);
+      digitalWrite(strobe, LOW);
+      digitalWrite(reset, HIGH);
 
       if (isInputPullup) {
         // initialize analog input 1 with internal pullup active
-        digitalWrite(A1, INPUT_PULLUP);
+        digitalWrite(output, INPUT_PULLUP);
       }
       else {
         // initialize analog input 1 without internal pullup active
-        digitalWrite(A1, INPUT);
+        digitalWrite(output, INPUT);
       }
     }
 
@@ -54,25 +51,25 @@ class MSGEQ7 {
     void read(uint16_t *levelRead) {
       // read back spectral band data from the MSGEQ7
       // start by setting RESET pin low to enable output
-      digitalWrite(RESET, LOW);
+      digitalWrite(reset, LOW);
       delayMicroseconds(100);
 
       // pulse STROBE pin to read all 7 frequency bands
       for(uint8_t k = 0; k < 7; k++) {
         // set STROBE pin low to enable output
-        digitalWrite(STROBE, LOW);
+        digitalWrite(strobe, LOW);
         delayMicroseconds(65);
 
         // read signal band level, account for later loudness adj.
-        levelRead[k] = analogRead(DCOUT) << 3;
+        levelRead[k] = analogRead(output) << 3;
 
         // set STROBE pin high again to prepare for next band reading
-        digitalWrite(STROBE, HIGH);
+        digitalWrite(strobe, HIGH);
         delayMicroseconds(35);
       }
 
       // set RESET high again to reset MSGEQ7 multiplexer
-      digitalWrite(RESET, HIGH);
+      digitalWrite(reset, HIGH);
 
       // spectral band adj. (very) loosely based on ISO 226:2003 [60 phons]
       levelRead[0] = levelRead[0] >> 3;   //   63 Hz
@@ -95,4 +92,11 @@ class MSGEQ7 {
       // much faster than divide-by-7, accurate to 7.00
       return (sum * 585L) >> 12;
     }
+
+
+  private:
+    bool isInputPullup;
+    uint8_t output;
+    uint8_t reset;
+    uint8_t strobe;
 };

--- a/opossum/parameters.h
+++ b/opossum/parameters.h
@@ -36,7 +36,7 @@
 
   // define the analogRead pins according to the schematic net name
   #define VOLUME (uint8_t)0
-  #define DCOUT  (uint8_t)1
+  #define DCOUT  (uint8_t)A1
 
   // time in ms between audio input level reads
   #define AUDIO_READ_INTERVAL (uint16_t)100


### PR DESCRIPTION
* Drivers now require pin numbers on init instead of using 'parameters.h' macros. Simplifies the way HW definitions are provided to the driver and improves portability of code
* restructured driver classes to put public methods first, followed by private methods