### PR TITLE
Experimental/audiomath private variables

### DIFF
--- a/Opossum.ino
+++ b/Opossum.ino
@@ -33,11 +33,11 @@
 #include "opossum/BM62.h"
 #include "opossum/BM62.cpp"
 
-#include "opossum/audiomath.h"
-#include "opossum/audiomath.cpp"
-
 #include "opossum/MAX9744.h"
 #include "opossum/MAX9744.cpp"
+
+#include "opossum/audiomath.h"
+#include "opossum/audiomath.cpp"
 
 #include "opossum/MSGEQ7.h"
 #include "opossum/MSGEQ7.cpp"

--- a/Opossum.ino
+++ b/Opossum.ino
@@ -249,14 +249,17 @@ void setup() {
   volume_out = analogRead(VOLUME);             // read Volume Control
   amplifier.volume(lowByte(volume_out >> 4));
   amplifier.unmute();
-  
-  // initialize levelBuf to nominal 'zero-signal' value
-  for (uint8_t k = 0; k < LEVEL_TRACK_BUFFER_SIZE; k++) {
-    levelBuf[k] = MSGEQ7_ZERO_SIGNAL_LEVEL;
-  }
-  
-  // read weighted audio level data, find mean, calculate buffer value
+
+  // read weighted audio level data from spectrum analyzer
   spectrum.read(levelRead, sizeof(levelRead));
+
+  // initialize levelBuf to initial audio level value
+  for (uint8_t k = 0; k < LEVEL_TRACK_BUFFER_SIZE; k++) {
+    uint16_t initial_signal_level = spectrum.mean(levelRead, sizeof(levelRead));
+    levelBuf[k] = initial_signal_level;
+  }
+
+  // calculate mean audio level from weighted data and update the level buffer
   audio_level = Audiomath::decayBuffer32(levelBuf, LEVEL_TRACK_BUFFER_SIZE,
                                          spectrum.mean(levelRead, sizeof(levelRead)), 
                                          MSGEQ7_ZERO_SIGNAL_LEVEL);

--- a/Opossum.ino
+++ b/Opossum.ino
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-// comment to deactivate varous debug modes
+// comment to deactivate various debug modes
 //#define DEBUG_BM62_SERIAL
 //#define DEBUG_LEVELOUT
 //#define DEBUG_VOLUME
@@ -45,6 +45,10 @@
 // declare built-in reset fuction at memory address 0
 void(* resetFunc) (void) = 0;
 
+// for tracking automatic gain control and EQ mode feature states
+bool feature_AGC_mode = false;
+bool feature_EQ_mode  = false;
+
 // use these for pulsing the AGC LED when making automated volume changes
 int8_t  agc_ledpulse_counter = 0;
 uint8_t agc_vm_index_previous = (DB_FAST_COEFFICIENT_COUNT >> 1);
@@ -60,9 +64,8 @@ uint16_t levelRead[MSGEQ7_SIGNAL_BAND_COUNT];
 uint16_t levelBuf[LEVEL_TRACK_BUFFER_SIZE];
 uint16_t dBLevels[DB_FAST_COEFFICIENT_COUNT];
 
-// for tracking automatic gain control and EQ mode feature states
-bool feature_AGC_mode = false;
-bool feature_EQ_mode  = false;
+// time of most recent audio level read (rolls over after about 50 days)
+uint32_t previousMillis = 0;
 
 // correlates to the number of switch state transitions registered [0, 1, 2, 3, or 4]
 enum feature 
@@ -73,9 +76,6 @@ enum feature
   feature_equalizer,
   feature_autovolume
 };
-
-// time of most recent audio level read (rolls over after about 50 days)
-uint32_t previousMillis = 0;
 
 // S2 interrupt debounce and timer values
 volatile bool     S2_button_read_ACTIVE       = false;

--- a/opossum/MAX9744.cpp
+++ b/opossum/MAX9744.cpp
@@ -20,7 +20,7 @@
 
 // MAX9744 amplifier gain levels (dB), stored as milli-Bells 
 // (1/100 of a dB) to allow PROGMEM storage as an int type
-static const int16_t MAX9744Gain_milliBels[64] PROGMEM = 
+const int16_t MAX9744::MAX9744Gain_milliBels[64] PROGMEM = 
 {
   -10950,  -9290,   -9030,   -8680,
   -8430,   -8080,   -7830,   -7470,

--- a/opossum/MAX9744.h
+++ b/opossum/MAX9744.h
@@ -22,6 +22,9 @@
   #include <avr/pgmspace.h>
   #include <Wire.h>
 
+  // maximum volume level of the MAX9744 amplifier
+  #define MAX9744_MAXIMUM_VOL_LEVEL  (uint8_t)63
+
   class MAX9744 {
     private:
       bool invert_mute;

--- a/opossum/MAX9744.h
+++ b/opossum/MAX9744.h
@@ -26,13 +26,6 @@
   #define MAX9744_MAXIMUM_VOL_LEVEL  (uint8_t)63
 
   class MAX9744 {
-    private:
-      bool invert_mute;
-      uint8_t i2c_addr;
-      uint8_t mute_p;
-      uint8_t shutdown_n;
-      TwoWire* wire;
-
     public:
       MAX9744(uint8_t i2c_addr, uint8_t mute_p, uint8_t shutdown_n, TwoWire* wire);
 
@@ -45,6 +38,14 @@
       void volume(const uint8_t value);
 
       static inline int16_t getGainAtVolumeIndex(const uint8_t index);
+
+    private:
+      bool invert_mute;
+      uint8_t i2c_addr;
+      uint8_t mute_p;
+      uint8_t shutdown_n;
+      static const int16_t MAX9744Gain_milliBels[64] PROGMEM;
+      TwoWire* wire;
   };
 
 #endif

--- a/opossum/MSGEQ7.h
+++ b/opossum/MSGEQ7.h
@@ -20,18 +20,18 @@
 #define MSGEQ7_H
 
   class MSGEQ7 {
-    private:
-      bool    isInputPullup;
-      uint8_t dc_out;
-      uint8_t reset_p;
-      uint8_t strobe_p;
-
     public:
       MSGEQ7(uint8_t strobe_p, uint8_t dc_out, uint8_t reset_p, bool isInputPullup);
 
       void     init(void);
       uint16_t mean(uint16_t array_values[], const size_t array_size);
       void     read(uint16_t array_values[], const size_t array_size);
+
+    private:
+      bool    isInputPullup;
+      uint8_t dc_out;
+      uint8_t reset_p;
+      uint8_t strobe_p;
   };
 
 #endif

--- a/opossum/audiomath.cpp
+++ b/opossum/audiomath.cpp
@@ -19,6 +19,18 @@
 #include <avr/pgmspace.h>
 
 #include "audiomath.h"
+#include "MAX9744.h"
+
+#ifndef AUDIOMATH_AGC_BOUND_VALUES
+#define AUDIOMATH_AGC_BOUND_VALUES
+
+  // AGC range bounds and analysis step size (in 1/100ths of a dB)
+  // these values must be hardcoded to match `coeffecients_dB`
+  #define MILLIBEL_BOUND_LOWER (int16_t) -600
+  #define MILLIBEL_BOUND_UPPER (int16_t)  600
+  #define MILLIBEL_STEP_SIZE   (int16_t)  50
+
+#endif
 
 // index for keeping track of the buffer used by decayBuffer32
 uint8_t Audiomath::buffer_indx_32 = 0;

--- a/opossum/audiomath.cpp
+++ b/opossum/audiomath.cpp
@@ -19,31 +19,15 @@
 #include <avr/pgmspace.h>
 
 #include "audiomath.h"
-#include "MAX9744.h"
-
-#ifndef OPOSSUM_AUDIOMATH_SYSTEM_PARAMETERS
-#define OPOSSUM_AUDIOMATH_SYSTEM_PARAMETERS
-
-  #define MAX9744_MAXIMUM_VOL_LEVEL  (uint8_t)63
-
-  #define DB_FAST_COEFFICIENT_COUNT (uint8_t)25
-
-  // AGC range bounds and analysis step size (in 1/100ths of a dB)
-  // these values must be hardcoded to match `coeffecients_dB`
-  #define MILLIBEL_BOUND_LOWER (int16_t) -600
-  #define MILLIBEL_BOUND_UPPER (int16_t)  600
-  #define MILLIBEL_STEP_SIZE   (int16_t)  50
-
-#endif
 
 // index for keeping track of the buffer used by decayBuffer32
-static uint8_t audiomath_buffer_indx_32 = 0;
+uint8_t Audiomath::buffer_indx_32 = 0;
 
 // index for keeping track of the most recent Volume Map index
-static uint8_t audiomath_vm_index_previous = (DB_FAST_COEFFICIENT_COUNT >> 1);
+uint8_t Audiomath::vm_index_previous = (DB_FAST_COEFFICIENT_COUNT >> 1);
 
 // Coefficient table for fast dB approximations
-static const uint16_t audiomath_dB_fast_coefficient[DB_FAST_COEFFICIENT_COUNT] PROGMEM =
+const uint16_t Audiomath::dB_fast_coefficient[DB_FAST_COEFFICIENT_COUNT] PROGMEM =
 {
   2053, 2175, 2303, 2440, 2584,
   2738, 2900, 3072, 3254, 3446,
@@ -55,7 +39,7 @@ static const uint16_t audiomath_dB_fast_coefficient[DB_FAST_COEFFICIENT_COUNT] P
 // update the relative dB level bands using currently defined volume level
 void Audiomath::dBFastRelativeLevel(uint16_t dBLevels[], const uint16_t baseLevel) {
   for(uint8_t k = 0; k < DB_FAST_COEFFICIENT_COUNT; k++) {
-    dBLevels[k] = ((uint32_t)baseLevel * pgm_read_word(&(audiomath_dB_fast_coefficient[k]))) >> 12;
+    dBLevels[k] = ((uint32_t)baseLevel * pgm_read_word(&(dB_fast_coefficient[k]))) >> 12;
   }
 }
 
@@ -84,13 +68,13 @@ uint16_t Audiomath::decayBuffer32(uint16_t data_buffer[], const size_t buffer_si
       return (uint16_t)0;
     }
     else {
-      if (audiomath_buffer_indx_32 >= 32) {
-        audiomath_buffer_indx_32 = 0;
+      if (buffer_indx_32 >= 32) {
+        buffer_indx_32 = 0;
       }
-      if (data_mean > data_buffer[audiomath_buffer_indx_32]) {
+      if (data_mean > data_buffer[buffer_indx_32]) {
         // if the new value is greater, use value halfway between old and new
-        data_buffer[audiomath_buffer_indx_32] = data_buffer[audiomath_buffer_indx_32] +
-          ((data_mean - data_buffer[audiomath_buffer_indx_32]) >> 1);
+        data_buffer[buffer_indx_32] = data_buffer[buffer_indx_32] +
+          ((data_mean - data_buffer[buffer_indx_32]) >> 1);
       }
       else if (data_mean < ((nominal_zero_signal_level * (uint16_t)18) >> 4)) {
         // if the latest level is less a small % over the nominal zero signal,
@@ -98,9 +82,9 @@ uint16_t Audiomath::decayBuffer32(uint16_t data_buffer[], const size_t buffer_si
       }
       else {
         // otherwise, decay the current value by approximately 16%
-        data_buffer[audiomath_buffer_indx_32] = (data_buffer[audiomath_buffer_indx_32] * 27L) >> 5;
+        data_buffer[buffer_indx_32] = (data_buffer[buffer_indx_32] * 27L) >> 5;
       }
-      audiomath_buffer_indx_32++;
+      buffer_indx_32++;
 
       // calculate total sum of exponential buffer array
       uint32_t sum = 0;
@@ -124,7 +108,7 @@ void Audiomath::mapVolumeToBoundedRange(const uint8_t volume, uint8_t volumeMap[
   int16_t gain_current_volume = MAX9744::getGainAtVolumeIndex(volume);
 
   // reset the volume map index used by getVolumeMapIndx() to the default mid value
-  audiomath_vm_index_previous = (DB_FAST_COEFFICIENT_COUNT >> 1);
+  vm_index_previous = (DB_FAST_COEFFICIENT_COUNT >> 1);
 
   // find the upper and lower bounds for volume values
   if (volume != 0) {
@@ -182,11 +166,11 @@ uint8_t Audiomath::getVolumeMapIndx(const uint16_t audio_level, const uint16_t d
   }
   for (int8_t k = (DB_FAST_COEFFICIENT_COUNT - 1); k >= 0; k--) {
     if (dBLevels[k] < audio_level) {
-      if (abs(audiomath_vm_index_previous - k) > 1) {
-        audiomath_vm_index_previous = k;
+      if (abs(vm_index_previous - k) > 1) {
+        vm_index_previous = k;
       }
       break;
     }
   }
-  return audiomath_vm_index_previous;
+  return vm_index_previous;
 }

--- a/opossum/audiomath.h
+++ b/opossum/audiomath.h
@@ -19,17 +19,34 @@
 #ifndef OPOSSUM_AUDIOMATH_H
 #define OPOSSUM_AUDIOMATH_H
 
+  #include "MAX9744.h"
+
+  // array in PROGMEM for storing dB coefficients
+  #define DB_FAST_COEFFICIENT_COUNT (uint8_t)25
+
+  // AGC range bounds and analysis step size (in 1/100ths of a dB)
+  // these values must be hardcoded to match `coeffecients_dB`
+  #define MILLIBEL_BOUND_LOWER (int16_t) -600
+  #define MILLIBEL_BOUND_UPPER (int16_t)  600
+  #define MILLIBEL_STEP_SIZE   (int16_t)  50
+
   class Audiomath {
     public:
       static void     convertVolumeToGain(const uint8_t start, const uint8_t stop, 
                                           int16_t values[], const size_t size);
       static void     dBFastRelativeLevel(uint16_t dBLevels[], const uint16_t baseLevel);
       static uint16_t decayBuffer32(uint16_t data_buffer[], const size_t buffer_size, 
-                                    uint16_t const data_mean, const uint16_t nominal_zero_signal_level);
+                                    uint16_t const data_mean, 
+                                    const uint16_t nominal_zero_signal_level);
       static void     mapVolumeToBoundedRange(const uint8_t volume, uint8_t volumeMap[], 
                                               const size_t size_volumeMap);
       static uint8_t  getVolumeMapIndx(const uint16_t audio_level, const uint16_t dBLevels[], 
                                        const size_t dBLevels_size);
+    
+    private:
+      static uint8_t buffer_indx_32;
+      static uint8_t vm_index_previous;
+      static const uint16_t dB_fast_coefficient[DB_FAST_COEFFICIENT_COUNT] PROGMEM;
   };
 
 #endif

--- a/opossum/audiomath.h
+++ b/opossum/audiomath.h
@@ -19,16 +19,8 @@
 #ifndef OPOSSUM_AUDIOMATH_H
 #define OPOSSUM_AUDIOMATH_H
 
-  #include "MAX9744.h"
-
   // array in PROGMEM for storing dB coefficients
   #define DB_FAST_COEFFICIENT_COUNT (uint8_t)25
-
-  // AGC range bounds and analysis step size (in 1/100ths of a dB)
-  // these values must be hardcoded to match `coeffecients_dB`
-  #define MILLIBEL_BOUND_LOWER (int16_t) -600
-  #define MILLIBEL_BOUND_UPPER (int16_t)  600
-  #define MILLIBEL_STEP_SIZE   (int16_t)  50
 
   class Audiomath {
     public:

--- a/opossum/ledbutton.h
+++ b/opossum/ledbutton.h
@@ -20,9 +20,6 @@
 #define LED_BUTTON_H
 
   class LED {
-    private:
-      int8_t led_pin;
-
     public:
       LED(int8_t led_pinAttachment);
 
@@ -32,14 +29,13 @@
       void off(void);
       void on(void);
       void reset(void);
+
+      private:
+      int8_t led_pin;
   };
 
 
   class Button {
-    private:    
-      const int8_t button_pin;
-      uint8_t button_port_input_mode;
-
     public:
       Button(uint8_t button_pinAttachment);
 
@@ -47,13 +43,14 @@
       void enableInputPullup(void);
       void init(void);
       bool read(void);
+
+      private:    
+      const int8_t button_pin;
+      uint8_t button_port_input_mode;
   };
 
 
   class LED_Button: public Button {
-    private:
-      LED led;
-
     public:
       LED_Button(int8_t button_pinAttachment, LED &led_Attachment);
     
@@ -64,6 +61,9 @@
       void init(void);
       void off(void);
       void unattach(void);
+
+    private:
+      LED led;
   };
 
 #endif

--- a/opossum/opossum.h
+++ b/opossum/opossum.h
@@ -41,7 +41,7 @@
   // control input pullup for analog pin measuring MSGEQ7 'DCOUT' value
   #define MSGEQ7_INPUT_PULLUP_ON_DC_OUT false
   #define MSGEQ7_SIGNAL_BAND_COUNT      (uint8_t)7
-  #define MSGEQ7_ZERO_SIGNAL_LEVEL      (uint16_t)300
+  #define MSGEQ7_ZERO_SIGNAL_LEVEL      (uint16_t)400
 
   // array size in samples of the level tracking buffer
   #define LEVEL_TRACK_BUFFER_SIZE       (uint16_t)32


### PR DESCRIPTION
modified `Audiomath` and `MAX9744` to make some previously exposed variables private