### PR TITLE
Feature/store agc and eq state to eeprom

### DIFF
--- a/Opossum.ino
+++ b/Opossum.ino
@@ -273,17 +273,13 @@ void setup() {
   #endif
 
   // By default all EEPROM registers are initialized to 0xFF, so if the address in question is
-  // equal to 0xFF then initialize it to 0x00 and modify the register at 0x00 to reflect this
-  // by setting the LSB to 0
-  if ((EEPROM.read(EEPROM_ADDR_INIT) & EEPROM_ADDR_FEATURE_STATE) == EEPROM_ADDR_FEATURE_STATE){
+  // equal to 0xFF then initialize it to 0x00 and modify the init register at 0x00 to reflect this
+  if (((uint8_t)EEPROM.read(EEPROM_ADDR_INIT_REG_0) & BM_INIT_REG_FEATURE) == BM_INIT_REG_FEATURE){
     EEPROM.update(EEPROM_ADDR_FEATURE_STATE, (int16_t)0x00);
-    EEPROM.update(EEPROM_ADDR_INIT, (EEPROM.read(EEPROM_ADDR_INIT) & ~EEPROM_ADDR_FEATURE_STATE));
+    EEPROM.update(EEPROM_ADDR_INIT_REG_0, 
+                 ((uint8_t)EEPROM.read(EEPROM_ADDR_INIT_REG_0) & (uint8_t)(~BM_INIT_REG_FEATURE)));
   }
-*/
-// delete this, one-time only code for resetting the EEPROM registers
-for (int k = 0; k <= 255; k++) {
-  EEPROM.update(k, 0xFF);
-}
+  
 
   if ((bool)(EEPROM.read(EEPROM_ADDR_FEATURE_STATE) & BM_EQ_STATE)) {
     feature_EQ_mode = true;

--- a/Opossum.ino
+++ b/Opossum.ino
@@ -24,6 +24,7 @@
 // include libraries for PROGMEM, SLEEP, & I2C
 #include <avr/pgmspace.h>
 #include <avr/wdt.h>
+#include <EEPROM.h>
 
 // include *.cpp files here b/c Arduino IDE won't find them unless installed as a library
 #include "opossum/opossum.h"

--- a/Opossum.ino
+++ b/Opossum.ino
@@ -20,6 +20,7 @@
 //#define DEBUG_BM62_SERIAL
 //#define DEBUG_LEVELOUT
 //#define DEBUG_VOLUME
+//#define DEBUG_EEPROM_RESET
 
 // include libraries for PROGMEM, SLEEP, & I2C
 #include <avr/pgmspace.h>
@@ -264,7 +265,13 @@ void setup() {
   // initialize base volume level and relative dB values
   Audiomath::dBFastRelativeLevel(dBLevels, audio_level);
 
-/*
+  // use this to reset the EEPROM registers to their default value (debug only!)
+  #ifdef DEBUG_EEPROM_RESET
+    for (int k = 0; k <= 255; k++) {
+      EEPROM.update(k, 0xFF);
+    }
+  #endif
+
   // By default all EEPROM registers are initialized to 0xFF, so if the address in question is
   // equal to 0xFF then initialize it to 0x00 and modify the register at 0x00 to reflect this
   // by setting the LSB to 0

--- a/Opossum.ino
+++ b/Opossum.ino
@@ -264,6 +264,20 @@ void setup() {
   // initialize base volume level and relative dB values
   Audiomath::dBFastRelativeLevel(dBLevels, audio_level);
 
+/*
+  // By default all EEPROM registers are initialized to 0xFF, so if the address in question is
+  // equal to 0xFF then initialize it to 0x00 and modify the register at 0x00 to reflect this
+  // by setting the LSB to 0
+  if ((EEPROM.read(EEPROM_ADDR_INIT) & EEPROM_ADDR_FEATURE_STATE) == EEPROM_ADDR_FEATURE_STATE){
+    EEPROM.update(EEPROM_ADDR_FEATURE_STATE, (int16_t)0x00);
+    EEPROM.update(EEPROM_ADDR_INIT, (EEPROM.read(EEPROM_ADDR_INIT) & ~EEPROM_ADDR_FEATURE_STATE));
+  }
+*/
+// delete this, one-time only code for resetting the EEPROM registers
+for (int k = 0; k <= 255; k++) {
+  EEPROM.update(k, 0xFF);
+}
+
   if ((bool)(EEPROM.read(EEPROM_ADDR_FEATURE_STATE) & BM_EQ_STATE)) {
     feature_EQ_mode = true;
     bluetooth.setEqualizerPreset(bluetooth.EQ_Classical);
@@ -278,6 +292,7 @@ void setup() {
     // set SW2 LED to default brightness to indicate that the AGC function is enabled
     ledbutton_SW2.brightness(S2_PWM_DEF);
   }
+
   // SW2 interrupt will often glitch and count when first enabled, so reset this here
   // (after establishing BT connection which gives us a delay) without checking it
   S2_interrupt_state_COUNT = 0;

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ At present, the system will automatically connect to a device via bluetooth, pla
   * ~~the 'adjustment range' needs to be mapped to the available gain steps which exist relative to the present gain setting, since this varies~~ _done_
   * ~~this is also going to need some kind of hysterysis~~ _done_
 * ~~automated gain adjustments should pulse the secondary front panel LED in the direction of the adjustment when they occur (`bright >> baseline >> bright` or `dim >> baseline >> dim`)~~ _done_
+* add EEPROM storage functionality for maintaining enabled/disabled state of AGC and EQ between power cycles
 
 #### Status: This project is maintained but considered complete. Additional features will be incorporated into future designs, but are unlikely to be added to Opossum. ####
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ At present, the system will automatically connect to a device via bluetooth, pla
   * ~~the 'adjustment range' needs to be mapped to the available gain steps which exist relative to the present gain setting, since this varies~~ _done_
   * ~~this is also going to need some kind of hysterysis~~ _done_
 * ~~automated gain adjustments should pulse the secondary front panel LED in the direction of the adjustment when they occur (`bright >> baseline >> bright` or `dim >> baseline >> dim`)~~ _done_
-* add EEPROM storage functionality for maintaining enabled/disabled state of AGC and EQ between power cycles
+* ~~add EEPROM storage functionality for maintaining enabled/disabled state of AGC and EQ between power cycles~~
 
 #### Status: This project is maintained but considered complete. Additional features will be incorporated into future designs, but are unlikely to be added to Opossum. ####
 

--- a/opossum/opossum.h
+++ b/opossum/opossum.h
@@ -22,6 +22,13 @@
   // define the MAX9744 I2C address, default is 0x4B
   #define MAX9744_I2CADDR ((uint8_t)0x4B)
 
+  // EEPROM Memory Address for storing AGC and EQ state between power cycles
+  #define EEPROM_ADDR_FEATURE_STATE (int16_t)0x0010
+
+  // EEPROM Bit Masks for storing AGC and EQ state between power cycles
+  #define BM_AGC_STATE (uint8_t)0b00000001
+  #define BM_EQ_STATE  (uint8_t)0b00000010
+
   // define the digitalOut pins according to the schematic net name
   #define S2_PIN       (uint8_t)3
   #define IND_A2DP_N   (uint8_t)4

--- a/opossum/opossum.h
+++ b/opossum/opossum.h
@@ -21,14 +21,13 @@
 
   // define the MAX9744 I2C address, default is 0x4B
   #define MAX9744_I2CADDR  (uint8_t)0x4B
-/*
-  // EEPROM Memory Address for storing the initialization state of EEPROM registers
-  #define EEPROM_ADDR_INIT (int16_t)0x00
-  #define EEPROM_BIT_INIT_FEATURE_STATE (int16_t)0x00
-  #define EEPROM_BIT_INIT_FEATURE_STATE (int16_t)0x00
-*/
+
+  // Use EEPROM Addresses 0x00-0x1F for storing the init state of the remaining registers
+  #define EEPROM_ADDR_INIT_REG_0 (int16_t)0x00
+
   // EEPROM Memory Address for storing AGC and EQ state between power cycles
-  #define EEPROM_ADDR_FEATURE_STATE (int16_t)0x0010
+  #define EEPROM_ADDR_FEATURE_STATE (int16_t)0x20
+  #define BM_INIT_REG_FEATURE       (uint8_t)0b00000001
 
   // EEPROM Bit Masks for storing AGC and EQ state between power cycles
   #define BM_AGC_STATE (uint8_t)0b00000001

--- a/opossum/opossum.h
+++ b/opossum/opossum.h
@@ -20,8 +20,13 @@
 #define OPOSSUM_H
 
   // define the MAX9744 I2C address, default is 0x4B
-  #define MAX9744_I2CADDR ((uint8_t)0x4B)
-
+  #define MAX9744_I2CADDR  (uint8_t)0x4B
+/*
+  // EEPROM Memory Address for storing the initialization state of EEPROM registers
+  #define EEPROM_ADDR_INIT (int16_t)0x00
+  #define EEPROM_BIT_INIT_FEATURE_STATE (int16_t)0x00
+  #define EEPROM_BIT_INIT_FEATURE_STATE (int16_t)0x00
+*/
   // EEPROM Memory Address for storing AGC and EQ state between power cycles
   #define EEPROM_ADDR_FEATURE_STATE (int16_t)0x0010
 


### PR DESCRIPTION
Adds EEPROM storage of enabled/disabled states for AGC and EQ such that the device boots up using the same configuration it was powered off with 